### PR TITLE
Extend R Markdown YAML metadata block terminator

### DIFF
--- a/R Markdown.sublime-syntax
+++ b/R Markdown.sublime-syntax
@@ -190,7 +190,7 @@ contexts:
         1: punctuation.definition.frontmatter
       embed: scope:source.yaml
       embed_scope: markup.raw.yaml.front-matter
-      escape: ^\s*(---)\s*$
+      escape: ^\s*(---|\.\.\.)\s*$
       escape_captures:
           1: punctuation.definition.frontmatter
     - match: ^\s*(\+\+\+)\s*$


### PR DESCRIPTION
The YAML (and pandoc) specification allows the block to be terminated by 3 dots as well as 3 dashes.