### PR TITLE
remove dangling lsp-rlang menu item

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -27,13 +27,6 @@
                                     "user_file": "${packages}/User/Default ($platform).sublime-keymap",
                                     "default": "[\n\t$0\n]\n"
                                 }
-                            },
-                            {
-                                "caption": "LSP-rlang Settings",
-                                "command": "edit_settings",
-                                "args": {
-                                    "base_file": "${packages}/R-IDE/LSP-rlang.sublime-settings"
-                                }
                             }
                         ]
                     }


### PR DESCRIPTION
The menu item was forgotten in a0a650d454fc310d616218b015d3e5f51368611d