### PR TITLE
Fix fenced code-block punctuation

### DIFF
--- a/R Markdown.sublime-syntax
+++ b/R Markdown.sublime-syntax
@@ -10,7 +10,7 @@ contexts:
 
   fenced-syntaxes:
     - meta_prepend: true
-    - match: (```)(\{)(bash)\b
+    - match: '[ \t]*(```)(\{)(bash)\b'
       captures:
         1: punctuation.definition.raw.code-fence.begin.markdown
         2: punctuation.definition.raw.code-fence.options.begin.markdown
@@ -28,7 +28,7 @@ contexts:
                 2: meta.fold.begin.markdown
               embed: scope:source.shell.bash
               embed_scope: markup.raw.code-fence.markdown
-              escape: (```)(\n?)
+              escape: ^[ \t]*(```)(\n?)
               escape_captures:
                 0: meta.code-fence.definition.end.markdown
                 1: punctuation.definition.raw.code-fence.end.markdown
@@ -36,7 +36,7 @@ contexts:
               pop: 1
         - include: scope:source.r#statements
 
-    - match: (```)(\{)(julia)\b
+    - match: '[ \t]*(```)(\{)(julia)\b'
       captures:
         1: punctuation.definition.raw.code-fence.begin.markdown
         2: punctuation.definition.raw.code-fence.options.begin.markdown
@@ -54,7 +54,7 @@ contexts:
                 2: meta.fold.begin.markdown
               embed: scope:source.julia
               embed_scope: markup.raw.code-fence.markdown
-              escape: (```)(\n?)
+              escape: ^[ \t]*(```)(\n?)
               escape_captures:
                 0: meta.code-fence.definition.end.markdown
                 1: punctuation.definition.raw.code-fence.end.markdown
@@ -62,7 +62,7 @@ contexts:
               pop: 1
         - include: scope:source.r#statements
 
-    - match: (```)(\{)(python)\b
+    - match: '[ \t]*(```)(\{)(python)\b'
       captures:
         1: punctuation.definition.raw.code-fence.begin.markdown
         2: punctuation.definition.raw.code-fence.options.begin.markdown
@@ -80,7 +80,7 @@ contexts:
                 2: meta.fold.begin.markdown
               embed: scope:source.python
               embed_scope: markup.raw.code-fence.markdown
-              escape: (```)(\n?)
+              escape: ^[ \t]*(```)(\n?)
               escape_captures:
                 0: meta.code-fence.definition.end.markdown
                 1: punctuation.definition.raw.code-fence.end.markdown
@@ -88,7 +88,7 @@ contexts:
               pop: 1
         - include: scope:source.r#statements
 
-    - match: (```)(\{)(r|Rscript)\b
+    - match: '[ \t]*(```)(\{)(r|Rscript)\b'
       captures:
         1: punctuation.definition.raw.code-fence.begin.markdown
         2: punctuation.definition.raw.code-fence.options.begin.markdown
@@ -106,7 +106,7 @@ contexts:
                 2: meta.fold.begin.markdown
               embed: scope:source.r
               embed_scope: markup.raw.code-fence.markdown
-              escape: (```)(\n?)
+              escape: ^[ \t]*(```)(\n?)
               escape_captures:
                 0: meta.code-fence.definition.end.markdown
                 1: punctuation.definition.raw.code-fence.end.markdown
@@ -114,7 +114,7 @@ contexts:
               pop: 1
         - include: scope:source.r#statements
 
-    - match: (```)(\{)(sql)\b
+    - match: '[ \t]*(```)(\{)(sql)\b'
       captures:
         1: punctuation.definition.raw.code-fence.begin.markdown
         2: punctuation.definition.raw.code-fence.options.begin.markdown
@@ -132,7 +132,7 @@ contexts:
                 2: meta.fold.begin.markdown
               embed: scope:source.sql
               embed_scope: markup.raw.code-fence.markdown
-              escape: (```)(\n?)
+              escape: ^[ \t]*(```)(\n?)
               escape_captures:
                 0: meta.code-fence.definition.end.markdown
                 1: punctuation.definition.raw.code-fence.end.markdown

--- a/syntax_test_rmarkdown.md
+++ b/syntax_test_rmarkdown.md
@@ -19,20 +19,6 @@
 foo
 | <- - meta.code-fence
 
-```{r}
-|^^^^^ meta.code-fence.definition.begin.markdown
-|^^ punctuation.definition.raw.code-fence.begin.markdown
-|  ^ punctuation.definition.raw.code-fence.options.begin.markdown
-|   ^ constant.other.language-name.markdown
-|    ^ punctuation.definition.raw.code-fence.options.end.markdown
- function(x) {x + 1}
-|^^^^^^^^ markup.raw.code-fence.markdown meta.function.r keyword.declaration.function.r
-```
-|^^ meta.code-fence.definition.end.markdown punctuation.definition.raw.code-fence.end.markdown
-
-foo
-| <- - meta.code-fence
-
 ```{python}
 |^^^^^^^^^^ meta.code-fence.definition.begin.markdown
 |^^ punctuation.definition.raw.code-fence.begin.markdown
@@ -47,6 +33,62 @@ def f():
 
 foo
 | <- - meta.code-fence
+
+```{r}
+|^^^^^^ meta.code-fence.definition.begin.markdown
+|^^ punctuation.definition.raw.code-fence.begin.markdown
+|  ^ punctuation.definition.raw.code-fence.options.begin.markdown
+|   ^ constant.other.language-name.markdown
+|    ^ punctuation.definition.raw.code-fence.options.end.markdown
+ function(x) {x + 1}
+|^^^^^^^^ markup.raw.code-fence.markdown meta.function.r keyword.declaration.function.r
+```
+| <- meta.code-fence.definition.end.markdown punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown meta.fold.end.markdown
+
+foo
+| <- - meta.code-fence
+
+   ```{r}
+|^^^^^^^^^ meta.code-fence.definition.begin.markdown
+|  ^^^ punctuation.definition.raw.code-fence.begin.markdown
+|     ^ punctuation.definition.raw.code-fence.options.begin.markdown
+|      ^ constant.other.language-name.markdown
+|       ^ punctuation.definition.raw.code-fence.options.end.markdown
+   func_producing_fenced_code_block(
+    '```{r attrib=value}',
+    'any r-code',
+    '```'
+|^^^^^^^^ markup.raw.code-fence.markdown meta.function-call.arguments.r
+|   ^^^^^ meta.string.r string.quoted.single.r
+|   ^ punctuation.definition.string.begin.r
+|       ^ punctuation.definition.string.end.r
+   )
+|^^^ markup.raw.code-fence.markdown meta.function-call.arguments.r
+|  ^ punctuation.section.arguments.end.r
+   ```
+|^^^^^^ meta.code-fence.definition.end.markdown
+|  ^^^ punctuation.definition.raw.code-fence.end.markdown
+
+- ```{r}
+|^^^^^^^ markup.list.unnumbered.markdown
+| ^^^^^^ meta.code-fence.definition.begin.markdown
+| ^^^ punctuation.definition.raw.code-fence.begin.markdown
+|    ^ punctuation.definition.raw.code-fence.options.begin.markdown
+|     ^ constant.other.language-name.markdown
+|      ^ punctuation.definition.raw.code-fence.options.end.markdown
+   func_producing_fenced_code_block(
+    '```{r attrib=value}',
+    'any r-code',
+    '```'
+|^^^^^^^^ markup.list.unnumbered.markdown markup.raw.code-fence.markdown meta.function-call.arguments.r
+|   ^^^^^ meta.string.r string.quoted.single.r
+|   ^ punctuation.definition.string.begin.r
+|       ^ punctuation.definition.string.end.r
+  ```
+|^^^^ meta.code-fence.definition.end.markdown
+| ^^^ punctuation.definition.raw.code-fence.end.markdown
 
 
 # Test inlines


### PR DESCRIPTION
Fixes #54

This commit...

1. ensures indented fenced code blocks are properly scoped by prepending `[ \t]*` to opening punctuation pattern

2. ensures indented fenced code blocks are properly terminated by expecting only whitespace in front of closing punctuation.

Note: BOL pattern (`^`) is checked only for closing punctuation to allow fenced code blocks in list items.