### PR TITLE
Fix some LaTeX math equations

### DIFF
--- a/R Markdown.sublime-syntax
+++ b/R Markdown.sublime-syntax
@@ -193,3 +193,54 @@ contexts:
       scope: invalid.illegal.non-terminated.raw.markdown
       pop: 1
     - include: scope:source.r#statements
+
+  math-inline:
+    - meta_append: true
+    # LaTeX \begin{...} \end{...} math blocks
+    - include: scope:text.tex.latex#block-math-begin-end-command
+    # Inline LaTeX Math Expressions with some heuristics
+    # to distinguish from normally escaped characters
+    - match: |-
+        (?x)
+        # begin
+        (\\\[)(?=\S)
+        # end
+        (?= .* [^\s\\\\](\\\\{2})*\\\](?!\w) )
+      scope:
+        markup.math.inline.markdown
+        text.tex.latex.embedded.markdown
+        meta.environment.math.block.dollar.latex
+        punctuation.definition.math.begin.latex
+      embed: math-content
+      embed_scope:
+        markup.math.inline.markdown
+        text.tex.latex.embedded.markdown
+        meta.environment.math.block.dollar.latex
+      escape: '{{no_escape_behind}}\\\]'
+      escape_captures:
+        0: markup.math.inline.markdown
+           text.tex.latex.embedded.markdown
+           meta.environment.math.block.dollar.latex
+           punctuation.definition.math.end.latex
+    - match: |-
+        (?x)
+        # begin
+        (\\\()(?=\S)
+        # end
+        (?= .* [^\s\\\\](\\\\{2})*\\\)(?!\w) )
+      scope:
+        markup.math.inline.markdown
+        text.tex.latex.embedded.markdown
+        meta.environment.math.block.dollar.latex
+        punctuation.definition.math.begin.latex
+      embed: math-content
+      embed_scope:
+        markup.math.inline.markdown
+        text.tex.latex.embedded.markdown
+        meta.environment.math.block.dollar.latex
+      escape: '{{no_escape_behind}}\\\)'
+      escape_captures:
+        0: markup.math.inline.markdown
+           text.tex.latex.embedded.markdown
+           meta.environment.math.block.dollar.latex
+           punctuation.definition.math.end.latex

--- a/syntax_test_rmarkdown.md
+++ b/syntax_test_rmarkdown.md
@@ -78,3 +78,35 @@ This is latex $x^2 = 3$
 |                  ^ keyword.operator.comparison.tex
 |                    ^ meta.number.integer.decimal.tex constant.numeric.value.tex
 |                     ^ punctuation.definition.math.end.latex
+
+Inline \[1 + 1\], but escaped \[ 1+1\] or \[1+1 \]
+|      ^^^^^^^^^ markup.math.inline.markdown text.tex.latex.embedded.markdown meta.environment.math.block.dollar.latex
+|                             ^^ constant.character.escape.markdown
+|                                   ^^ constant.character.escape.markdown
+|                                         ^^ constant.character.escape.markdown
+|                                               ^^ constant.character.escape.markdown
+
+Inline \(1 + 1\), but escaped \( 1+1\) or \(1+1 \)
+|      ^^^^^^^^^ markup.math.inline.markdown text.tex.latex.embedded.markdown meta.environment.math.block.dollar.latex
+|                             ^^ constant.character.escape.markdown
+|                                   ^^ constant.character.escape.markdown
+|                                         ^^ constant.character.escape.markdown
+|                                               ^^ constant.character.escape.markdown
+
+LaTeX \begin{equation}\overline{Y}_{g,t}\end{equation}.
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph.markdown
+|     ^^^^^^^^^^^^^^^^ meta.function.begin.latex
+|     ^^^^^^ keyword.declaration.environment.begin.latex
+|     ^ punctuation.definition.backslash.latex
+|           ^^^^^^^^^^ meta.group.brace.tex
+|           ^ punctuation.definition.group.brace.begin.tex
+|            ^^^^^^^^ variable.parameter.function.latex
+|                    ^ punctuation.definition.group.brace.end.tex
+|                     ^^^^^^^^^^^^^^^^^^ meta.environment.math.block.latex markup.math.block
+|                                       ^^^^^^^^^^^^^^ meta.function.end.latex
+|                                       ^^^^ keyword.declaration.environment.end.latex
+|                                       ^ punctuation.definition.backslash.latex
+|                                           ^^^^^^^^^^ meta.group.brace.tex
+|                                           ^ punctuation.definition.group.brace.begin.tex
+|                                            ^^^^^^^^ variable.parameter.function.latex
+|                                                    ^ punctuation.definition.group.brace.end.tex


### PR DESCRIPTION
Resolves #45
Resolves #47

This PR...

1. (re-)adds support for `\begin{equation}...\end{equation}` style math blocks, which are not supported by CommonMark or GFM Markdown.

2. adds support for equation wrapped in `\[...\]` and `\(...\)`. Note, it uses some heuristics to distinguish them from normal escapes.